### PR TITLE
fixed swap for 3+ players

### DIFF
--- a/src/main/java/com/magusgeek/brutaltester/GameThread.java
+++ b/src/main/java/com/magusgeek/brutaltester/GameThread.java
@@ -139,7 +139,7 @@ public class GameThread extends Thread {
                     char c = line.charAt(i);
                     if (c >= '0' && c <= '9') {
                         c -= '0';
-                        c += players.size() - rotate;
+                        c += rotate;
                         c %= players.size();
                         c += '0';
                     }


### PR DESCRIPTION
Unfortunately I rotated the players in the wrong direction, which worked fine for 2 players, but lead to incorrect mapping for more players.

This should fix it, at least I get 100% wins against a WAIT bot now.