### PR TITLE
Tries to print logs from referee when proper game result not found

### DIFF
--- a/src/main/java/com/magusgeek/brutaltester/GameThread.java
+++ b/src/main/java/com/magusgeek/brutaltester/GameThread.java
@@ -80,19 +80,41 @@ public class GameThread extends Thread {
 
 				int[] scores = new int[playersCount];
 
+				StringBuilder fullOut = new StringBuilder();
 				try (Scanner in = referee.getIn()) {
 					for (int i = 0; i < playersCount; ++i) {
-						scores[i] = in.nextInt();
+						if (in.hasNextInt())
+						{
+							scores[i] = in.nextInt();
+						}
+						else
+						{
+							while(!in.hasNextInt() && in.hasNext())
+							{
+								fullOut.append(in.nextLine()).append("\n");
+							}
+
+							// Try again after referee messages are out of the way
+							if (in.hasNextInt())
+							{
+								scores[i] = in.nextInt();
+							}
+						}
 
 						if (scores[i] < 0) {
 							error = true;
-							LOG.error("Negative score during game " + game);
+							LOG.error("Negative score during game " + game + " p" + i + ":" + scores[i]);
 						}
 					}
 
 					while (in.hasNextLine()) {
 						data.append(in.nextLine()).append("\n");
 					}
+				}
+
+				if (fullOut.length()>0)
+				{
+					LOG.error("Problem with referee output in game" + game + ". Output content:" + fullOut);
 				}
 
 				if (checkForError()) {


### PR DESCRIPTION
Hi @dreignier,

added some wrap around code to help debug why failures at referee/player side happend. The referee logs are formatted in a way they won't start with a digit, so on this assumption one can distinguish them from expected player output (number representing player's score).

Surely one needs to test referee and players separately, but some errors appear rarely and only get visible once running hundreds of test with brutaltester, so it's nice to have the option. In case of referee crashes there is no log file for that game (at least that was my experience with CoK).

Also line 106 shows now which player failed.

Btw. my CoK referee for brutalster (I started a pull towards original CoK repo already): https://github.com/fala13/code-of-kutulu
and all the stuff for CoK compiled: https://github.com/fala13/CoK_artifacts
