### PR TITLE
remove log4j 1.x bridge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jcl</artifactId>
-            <version>2.4.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.3.1</version>


### PR DESCRIPTION
I noticed the same issue as in #29 . It seems like the versions of log4j-core and log4j-jcl (the log4j 1.x bridge) have to match to avoid class loading errors. Fortunately, though, it looks like you're not actually using any features of log4j-jcl, so we can just remove it.

I'm not an expert on this maven and this repository, so you might want to double check that this builds on your end before merging.